### PR TITLE
feat: rerender on cache changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ If a `loader` is present, it will be called with the missing keys and those keys
   }
 ```
 
+#### Automatic rerender
+
+If a component calls `get()` for some keys it subscribes to further changes to that entry.
+When this or any other components alters that entry through one of the writing methods described below,
+the component automatically rerenders.
+
 ### Set
 
 #### Set a single value
@@ -217,7 +223,8 @@ You can set values in the react cache but not in IndexedDB:
 ```
 
 #### Filter entries per callback
-Clears the cache and also deletes some data from IndexedDB.
+
+Deletes some data from cache and IndexedDB.
 ```js
   const { clear } = useCached()
   clear(({data, meta}) => meta.someMetaField > 2) // this will remove all entries with meta.someMetaField > 2

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "react-idb-cache",
     "description": "Cache for React",
     "author": "Philipp Fritsche",
+    "license": "MIT",
     "repository": "https://github.com/ph-fritsche/react-idb-cache.git",
     "keywords": [
         "React",

--- a/src/methods/clear.ts
+++ b/src/methods/clear.ts
@@ -1,5 +1,5 @@
 import { entries, setMany, clear as idbClear } from 'idb-keyval'
-import { expire, reactCache, verifyEntry } from '../shared'
+import { delProperty, dispatch, expire, reactCache, verifyEntry } from '../shared'
 
 export async function clear(
     cache: reactCache,
@@ -17,11 +17,18 @@ export async function clear(
         : idbClear(store)
     )
 
-    return Object.entries(cache).forEach(([key, entry]) => {
-        if (entry.promise) {
-            delete entry.obj
+    const keys: string[] = []
+    Object.entries(cache).forEach(([key, entry]) => {
+        if (expire) {
+            if (!verifyEntry({ obj: entry.obj }, expire)) {
+                keys.push(key)
+                delProperty(cache, [key, 'obj'])
+            }
         } else {
-            delete cache[key]
+            keys.push(key)
+            delProperty(cache, [key, 'obj'])
         }
     })
+
+    dispatch(cache, keys)
 }

--- a/src/methods/del.ts
+++ b/src/methods/del.ts
@@ -1,5 +1,5 @@
 import { del as idbDel } from 'idb-keyval'
-import { reactCache } from '../shared'
+import { delProperty, dispatch, reactCache } from '../shared'
 
 export async function del(
     cache: reactCache,
@@ -7,5 +7,7 @@ export async function del(
     key: string,
 ): Promise<void> {
     await idbDel(key, store)
-    delete cache[key]
+    delProperty(cache, [key, 'obj'])
+
+    dispatch(cache, [key])
 }

--- a/src/methods/get.ts
+++ b/src/methods/get.ts
@@ -24,7 +24,7 @@ export function get<
     store: Parameters<typeof getMany>[1],
     rerender: () => void,
     keyOrKeys: K,
-    loader?: (missingKeys: string[]) => Promise<void> | undefined,
+    loader?: (missingKeys: string[]) => Promise<void>,
     expire?: expire | undefined,
     returnType?: undefined,
 ): getReturn<K, undefined>;
@@ -36,8 +36,8 @@ export function get<
     store: Parameters<typeof getMany>[1],
     rerender: () => void,
     keyOrKeys: K,
-    loader?: (missingKeys: string[]) => Promise<void> | undefined,
-    expire?: expire | undefined,
+    loader?: (missingKeys: string[]) => Promise<void>,
+    expire?: expire,
     returnType?: T,
 ): getReturn<K, T>;
 
@@ -49,11 +49,11 @@ export function get<
     store: Parameters<typeof getMany>[1],
     rerender: () => void,
     keyOrKeys: K,
-    loader?: (missingKeys: string[]) => Promise<void> | undefined,
-    expire?: expire | undefined,
+    loader?: (missingKeys: string[]) => Promise<void>,
+    expire?: expire,
     returnType?: T,
 ): getReturn<K, T> {
-    const keys = Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys]
+    const keys = (Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys]) as string[]
 
     const values: Record<string, getValue<T>> = {}
     const missing: string[] = []

--- a/src/methods/index.ts
+++ b/src/methods/index.ts
@@ -14,12 +14,12 @@ declare function boundDel(
 ): Promise<void>;
 
 declare function boundGet<
-    K extends Parameters<typeof get>[3],
-    T extends Parameters<typeof get>[6],
+    K extends Parameters<typeof get>[4],
+    T extends Parameters<typeof get>[7],
 >(
     keyOrKeys: K,
-    loader?: Parameters<typeof get>[4],
-    expire?: Parameters<typeof get>[5],
+    loader?: Parameters<typeof get>[5],
+    expire?: Parameters<typeof get>[6],
     returnType?: T,
 ): getReturn<K, T>;
 
@@ -42,11 +42,11 @@ interface cachedApi {
     set: typeof boundSet,
 }
 
-export function createApi(cache: reactCache, store: ReturnType<typeof createStore>, rerender: () => void): cachedApi {
+export function createApi(cache: reactCache, store: ReturnType<typeof createStore>, id: string, rerender: () => void): cachedApi {
     return {
         clear: clear.bind(undefined, cache, store) as typeof boundClear,
         del: del.bind(undefined, cache, store) as typeof boundDel,
-        get: get.bind(undefined, cache, store, rerender) as typeof boundGet,
-        set: set.bind(undefined, cache, store, rerender) as typeof boundSet,
+        get: get.bind(undefined, cache, store, id, rerender) as typeof boundGet,
+        set: set.bind(undefined, cache, store) as typeof boundSet,
     }
 }

--- a/src/shared/cache.ts
+++ b/src/shared/cache.ts
@@ -1,6 +1,7 @@
 export interface reactCacheEntry {
     promise?: Promise<cachedObj | undefined>,
     obj?: cachedObj,
+    listeners?: Record<string, () => void>,
 }
 
 export type reactCache = Record<string, reactCacheEntry>

--- a/src/shared/debug.ts
+++ b/src/shared/debug.ts
@@ -1,3 +1,3 @@
 import debugLib from 'debug'
 
-export const debugLog = debugLib('react-idb-cached')
+export const debugLog = debugLib('react-idb-cache')

--- a/src/shared/event.ts
+++ b/src/shared/event.ts
@@ -16,10 +16,18 @@ export function removeListener(
     cache: reactCache,
     id: string,
     keys?: (keyof reactCache)[],
-): void {
-    (keys ?? Object.keys(cache)).forEach(key => {
-        delProperty(cache, [key, 'listeners', id])
+): (keyof reactCache)[] {
+    const removedKeys: (keyof reactCache)[] = []
+    const traverseKeys = (keys ?? Object.keys(cache))
+
+    traverseKeys.forEach(key => {
+        if (cache[key]?.listeners?.[id]) {
+            delProperty(cache, [key, 'listeners', id])
+            removedKeys.push(key)
+        }
     })
+
+    return removedKeys
 }
 
 export function dispatch(
@@ -27,6 +35,7 @@ export function dispatch(
     keys: (keyof reactCache)[],
 ): void {
     const listeners: reactCacheEntry['listeners'] = {}
+
     keys.forEach(key => {
         Object.entries(cache[key]?.listeners ?? {}).forEach(([id, listener]) => {
             listeners[id] = listener

--- a/src/shared/event.ts
+++ b/src/shared/event.ts
@@ -1,0 +1,37 @@
+import { reactCache, reactCacheEntry } from './cache'
+import { delProperty, setProperty } from './object'
+
+export function addListener(
+    cache: reactCache,
+    keys: (keyof reactCache)[],
+    id: string,
+    listener: () => void,
+): void {
+    keys.forEach(key => {
+        setProperty(cache, [key, 'listeners', id], listener)
+    })
+}
+
+export function removeListener(
+    cache: reactCache,
+    id: string,
+    keys?: (keyof reactCache)[],
+): void {
+    (keys ?? Object.keys(cache)).forEach(key => {
+        delProperty(cache, [key, 'listeners', id])
+    })
+}
+
+export function dispatch(
+    cache: reactCache,
+    keys: (keyof reactCache)[],
+): void {
+    const listeners: reactCacheEntry['listeners'] = {}
+    keys.forEach(key => {
+        Object.entries(cache[key]?.listeners ?? {}).forEach(([id, listener]) => {
+            listeners[id] = listener
+        })
+    })
+
+    Object.values(listeners).forEach(listener => listener())
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,4 +1,6 @@
 export * from './cache'
 export * from './debug'
+export * from './event'
+export * from './object'
 export * from './options'
 export * from './verifyEntry'

--- a/src/shared/object.ts
+++ b/src/shared/object.ts
@@ -1,0 +1,45 @@
+export function setProperty(obj: Record<string, unknown>, keys: string[], value: unknown): void {
+    for(
+        let o = obj, i = 0;
+        i < keys.length;
+        o = o[keys[i]] as Record<string, unknown>, i++
+    ) {
+        if (o !== undefined && !(o instanceof Object) || Array.isArray(o)) {
+            throw `Unexpected type at $obj.${keys.join('.')}`
+        }
+        if (i < keys.length -1) {
+            o[keys[i]] = o[keys[i]] ?? {}
+        } else {
+            o[keys[i]] = value
+        }
+    }
+}
+
+export function delProperty(obj: Record<string, unknown>, keys: string[]): void {
+    const objects: Record<string, unknown>[] = []
+    let o, i
+    for(
+        o = obj, i = 0;
+        i < keys.length;
+        o = o[keys[i]] as Record<string, unknown>, i++
+    ) {
+        if (o !== undefined && !(o instanceof Object) || Array.isArray(o)) {
+            throw `Unexpected type at $obj.${keys.join('.')}`
+        }
+        objects.push(o)
+        if (o[keys[i]] === undefined) {
+            break
+        }
+    }
+    for(
+        i = objects.length - 1;
+        i >= 0;
+        i--
+    ) {
+        if ((i === keys.length - 1) || objects[i+1] !== undefined && Object.keys(objects[i+1]).length === 0) {
+            delete objects[i][keys[i]]
+        } else {
+            break
+        }
+    }
+}

--- a/src/shared/verifyEntry.ts
+++ b/src/shared/verifyEntry.ts
@@ -1,9 +1,7 @@
 import { expire, reactCacheEntry } from './cache'
 
 export function verifyEntry(entry: reactCacheEntry | undefined, expire: expire | undefined): boolean {
-    if (entry?.promise instanceof Promise) {
-        return true
-    } else if (!entry?.obj) {
+    if (!entry?.obj) {
         return false
     }
 

--- a/src/useCached.ts
+++ b/src/useCached.ts
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { createStore } from 'idb-keyval'
-import { reactCache } from './shared'
+import { reactCache, removeListener } from './shared'
 import { createApi } from './methods'
 import { CacheContext } from './context'
 
@@ -24,21 +24,16 @@ export function useCached({dbName = 'Cached', storeName = 'keyval', context = tr
     }
     const cache = context ? contextCache[dbName][storeName] : componentCache
 
+    const id = useRef(Math.random().toString(36)).current
     const [, setState] = useState({})
 
-    const mounted = useRef(true)
     useEffect(() => {
-        mounted.current = true
-        return () => { mounted.current = false}
+        return () => {
+            removeListener(cache, id)
+        }
     })
 
-    const api = useMemo(() => createApi(cache, store,
-        () => {
-            if (mounted.current) {
-                setState({})
-            }
-        },
-    ), [cache, store, setState])
+    const api = useMemo(() => createApi(cache, store, id, () => setState({})), [cache, store, id, setState])
 
     return api
 }

--- a/test/methods/_.ts
+++ b/test/methods/_.ts
@@ -2,7 +2,8 @@ import { clear, createStore, setMany } from 'idb-keyval';
 import { createApi } from '../../src/methods';
 import { cachedObj, reactCache, reactCacheEntry } from '../../src/shared';
 
-export async function setupApi({cacheEntries, cacheObjects, cacheValues, idbObjects, idbValues}: {
+export async function setupApi({cache: reactCache, cacheEntries, cacheObjects, cacheValues, idbObjects, idbValues}: {
+    cache?: reactCache,
     cacheEntries?: Record<string, reactCacheEntry>,
     cacheObjects?: Record<string, cachedObj>,
     cacheValues?: Record<string, unknown>,
@@ -14,7 +15,7 @@ export async function setupApi({cacheEntries, cacheObjects, cacheValues, idbObje
     rerender: jest.Mock<() => void>,
     api: ReturnType<typeof createApi>,
 }> {
-    const cache: reactCache = {}
+    const cache: reactCache = reactCache ?? {}
     Object.entries(cacheEntries ?? {}).forEach(([key, entry]) => {
         cache[key] = entry
     })

--- a/test/methods/_.ts
+++ b/test/methods/_.ts
@@ -1,18 +1,20 @@
 import { clear, createStore, setMany } from 'idb-keyval';
 import { createApi } from '../../src/methods';
-import { cachedObj, reactCache, reactCacheEntry } from '../../src/shared';
+import { addListener, cachedObj, reactCache, reactCacheEntry } from '../../src/shared';
 
-export async function setupApi({cache: reactCache, cacheEntries, cacheObjects, cacheValues, idbObjects, idbValues}: {
+export async function setupApi({cache: reactCache, cacheEntries, cacheObjects, cacheValues, idbObjects, idbValues, listen}: {
     cache?: reactCache,
     cacheEntries?: Record<string, reactCacheEntry>,
     cacheObjects?: Record<string, cachedObj>,
     cacheValues?: Record<string, unknown>,
     idbObjects?: Record<string, cachedObj>,
     idbValues?: Record<string, unknown>,
+    listen?: string[],
 } = {}): Promise<{
     cache: reactCache,
     store: ReturnType<typeof createStore>,
     rerender: jest.Mock<() => void>,
+    listener: jest.Mock<() => void>,
     api: ReturnType<typeof createApi>,
 }> {
     const cache: reactCache = reactCache ?? {}
@@ -41,12 +43,19 @@ export async function setupApi({cache: reactCache, cacheEntries, cacheObjects, c
 
     const rerender = jest.fn()
 
-    const api = createApi(cache, store, rerender)
+    const listener = jest.fn()
+    const listenerId = Math.random().toString(36)
+    if (listen) {
+        addListener(cache, listen, listenerId, listener)
+    }
+
+    const api = createApi(cache, store, 'testComponent', rerender)
 
     return {
         cache: cache as reactCache,
         store,
         rerender,
+        listener,
         api,
     }
 }

--- a/test/methods/del.ts
+++ b/test/methods/del.ts
@@ -2,17 +2,25 @@ import { get } from 'idb-keyval'
 import { setupApi } from './_'
 
 it('delete entry from cache', async () => {
-    const { cache, api } = await setupApi({cacheValues: {foo: 'bar'}})
+    const { cache, api, listener } = await setupApi({
+        cacheValues: {foo: 'bar'},
+        listen: ['foo'],
+    })
 
     await api.del('foo')
 
-    expect(cache.foo).toBe(undefined)
+    expect(cache.foo?.obj).toBe(undefined)
+    expect(listener).toHaveBeenCalledTimes(1)
 })
 
 it('delete entry from idb', async () => {
-    const { store, api } = await setupApi({idbValues: { foo: 'bar' }})
+    const { store, api, listener } = await setupApi({
+        idbValues: { foo: 'bar' },
+        listen: ['foo'],
+    })
 
     await api.del('foo')
 
     expect(await get('foo', store)).toBe(undefined)
+    expect(listener).toHaveBeenCalledTimes(1)
 })

--- a/test/methods/get.ts
+++ b/test/methods/get.ts
@@ -1,4 +1,3 @@
-import { waitFor } from '@testing-library/react'
 import { setupApi } from './_'
 
 it('get value from cache', async () => {
@@ -152,25 +151,4 @@ it('skip fetching object when a promise is pending', async () => {
     expect(api.get('foo', loader)).toEqual(undefined)
     await new Promise(r => setTimeout(r, 1))
     expect(loader).toBeCalledTimes(2)
-})
-
-it('rerender when pending promise is resolved', async () => {
-    const compA = await setupApi()
-    const compB = await setupApi({cache: compA.cache})
-    let resolveLoader: () => void = () => { return }
-    const loader = jest.fn(() => new Promise<void>(r => { resolveLoader = r }))
-
-    expect(compA.api.get('foo', loader)).toBe(undefined)
-    expect(compB.api.get('foo', loader)).toBe(undefined)
-
-    await waitFor(() => expect(resolveLoader).toBeTruthy())
-    expect(loader).toHaveBeenCalledTimes(1)
-
-    resolveLoader()
-    await new Promise(r => setTimeout(r, 1))
-
-    expect(compA.rerender).toBeCalledTimes(1)
-    expect(compA.api.get('foo')).toBe('foo')
-    expect(compB.rerender).toBeCalledTimes(1)
-    expect(compB.api.get('foo')).toBe('foo')
 })

--- a/test/methods/set.ts
+++ b/test/methods/set.ts
@@ -2,17 +2,20 @@ import { get, getMany } from 'idb-keyval'
 import { setupApi } from './_'
 
 it('set value', async () => {
-    const { cache, store, rerender, api } = await setupApi()
+    const { cache, store, listener, api } = await setupApi({listen: ['foo']})
 
     await api.set('foo', 'bar')
 
     expect(cache.foo?.obj).toEqual(expect.objectContaining({data: 'bar'}))
     await expect(get('foo', store)).resolves.toEqual(expect.objectContaining({data: 'bar'}))
-    expect(rerender).toBeCalledTimes(1)
+    expect(listener).toBeCalledTimes(1)
 })
 
 it('set multiple values', async () => {
-    const { cache, store, rerender, api } = await setupApi({cacheValues: {foo: undefined}})
+    const { cache, store, listener, api } = await setupApi({
+        cacheValues: {foo: undefined},
+        listen: ['foo'],
+    })
 
     await api.set({foo: 'bar', fuu: 'baz'})
 
@@ -22,11 +25,11 @@ it('set multiple values', async () => {
         expect.objectContaining({data: 'bar'}),
         expect.objectContaining({data: 'baz'}),
     ])
-    expect(rerender).toBeCalledTimes(1)
+    expect(listener).toBeCalledTimes(1)
 })
 
 it('set value with meta', async () => {
-    const { cache, store, rerender, api } = await setupApi()
+    const { cache, store, listener, api } = await setupApi({listen: ['foo']})
 
     await api.set('foo', 'bar', {someMeta: 'someMetaValue'})
 
@@ -38,11 +41,11 @@ it('set value with meta', async () => {
         data: 'bar',
         meta: expect.objectContaining({ someMeta: 'someMetaValue' }),
     })
-    expect(rerender).toBeCalledTimes(1)
+    expect(listener).toBeCalledTimes(1)
 })
 
 it('set multiple values with meta', async () => {
-    const { cache, store, rerender, api } = await setupApi()
+    const { cache, store, listener, api } = await setupApi({listen: ['foo', 'fuu']})
 
     await api.set({foo: 'bar', fuu: 'baz'}, {
         foo: {someMeta: 'someMetaValue'},
@@ -67,11 +70,14 @@ it('set multiple values with meta', async () => {
             meta: expect.objectContaining({ someMeta: 'otherMetaValue' }),
         },
     ])
-    expect(rerender).toBeCalledTimes(1)
+    expect(listener).toBeCalledTimes(1)
 })
 
 it('unset per meta=null', async () => {
-    const { cache, store, rerender, api } = await setupApi({idbValues: {foo: 'bar', fuu: 'baz'}})
+    const { cache, store, listener, api } = await setupApi({
+        idbValues: {foo: 'bar', fuu: 'baz'},
+        listen: ['foo', 'fuu'],
+    })
 
     await api.set({ foo: 'newValue', fuu: 'doesNotMatter' }, {
         fuu: null,
@@ -83,7 +89,7 @@ it('unset per meta=null', async () => {
         expect.objectContaining({ data: 'newValue' }),
         undefined,
     ])
-    expect(rerender).toBeCalledTimes(1)
+    expect(listener).toBeCalledTimes(1)
 })
 
 it('preserve promises when unsetting entries', async () => {

--- a/test/shared/event.ts
+++ b/test/shared/event.ts
@@ -1,0 +1,76 @@
+import { addListener, dispatch, removeListener } from '../../src/shared'
+
+it('add listeners', () => {
+    const listenerA = () => { return }
+    const listenerB = () => { return }
+    const cache = {}
+
+    addListener(cache, ['foo', 'bar'], 'listenerTestA', listenerA)
+    addListener(cache, ['bar'], 'listenerTestB', listenerB)
+
+    expect(cache).toEqual({
+        foo: {
+            listeners: {
+                listenerTestA: listenerA,
+            },
+        },
+        bar: {
+            listeners: {
+                listenerTestA: listenerA,
+                listenerTestB: listenerB,
+            },
+        },
+    })
+})
+
+it('remove listeners', () => {
+    const listenerA = () => { return }
+    const listenerB = () => { return }
+    const cache = {
+        foo: {
+            listeners: {
+                listenerTestA: listenerA,
+            },
+        },
+        bar: {
+            listeners: {
+                listenerTestA: listenerA,
+                listenerTestB: listenerB,
+            },
+        },
+    }
+
+    removeListener(cache, 'listenerTestA', ['foo', 'baz'])
+    removeListener(cache, 'listenerTestB')
+
+    expect(cache).toEqual({
+        bar: {
+            listeners: {
+                listenerTestA: listenerA,
+            },
+        },
+    })
+})
+
+it('dispatch listeners', () => {
+    const listenerA = jest.fn()
+    const listenerB = jest.fn()
+    const cache = {
+        foo: {
+            listeners: {
+                listenerTestA: listenerA,
+            },
+        },
+        bar: {
+            listeners: {
+                listenerTestA: listenerA,
+                listenerTestB: listenerB,
+            },
+        },
+    }
+
+    dispatch(cache, ['foo', 'bar'])
+
+    expect(listenerA).toBeCalledTimes(1)
+    expect(listenerB).toBeCalledTimes(1)
+})

--- a/test/shared/event.ts
+++ b/test/shared/event.ts
@@ -40,8 +40,8 @@ it('remove listeners', () => {
         },
     }
 
-    removeListener(cache, 'listenerTestA', ['foo', 'baz'])
-    removeListener(cache, 'listenerTestB')
+    expect(removeListener(cache, 'listenerTestA', ['foo', 'baz'])).toEqual(['foo'])
+    expect(removeListener(cache, 'listenerTestB')).toEqual(['bar'])
 
     expect(cache).toEqual({
         bar: {

--- a/test/shared/object.ts
+++ b/test/shared/object.ts
@@ -1,0 +1,33 @@
+import { delProperty, setProperty } from '../../src/shared/object'
+
+it('set deep property', () => {
+    const o = {}
+    setProperty(o, ['a', 'b', 'c'], 'foo')
+    expect(o).toEqual({a: {b: {c: 'foo'}}})
+})
+
+it('throw exception when trying to set property on non-object', () => {
+    const o = {a: {b: []}}
+    expect(() => setProperty(o, ['a', 'b', 'c'], 'foo')).toThrow('$obj.a.b')
+})
+
+it('del deep property', () => {
+    const o = {a: {b0: {c: 'foo'}, b1: {c: 'foo'}}}
+    delProperty(o, ['a', 'b0', 'c'])
+    expect(o).toEqual({a: {b1: {c: 'foo'}}})
+})
+
+it('throw exception when trying to delete property from non-object', () => {
+    const o = { a: { b: [] } }
+    expect(() => delProperty(o, ['a', 'b', 'c'])).toThrow('$obj.a.b')
+})
+
+it('handle non-existing keys', () => {
+    const o = { a: { b1: { c: 'foo' } } }
+    delProperty(o, ['a', 'b2', 'c'])
+    expect(o).toEqual({ a: { b1: { c: 'foo' } } })
+
+    const p = { a: { b: {} } }
+    delProperty(p, ['a', 'b', 'c'])
+    expect(p).toEqual({})
+})

--- a/test/shared/verifyEntry.ts
+++ b/test/shared/verifyEntry.ts
@@ -1,0 +1,44 @@
+import { verifyEntry } from '../../src/shared'
+
+it('return false for non-existent objects', () => {
+    const expire = jest.fn()
+
+    expect(verifyEntry(undefined, expire)).toBe(false)
+    expect(verifyEntry({obj: undefined}, expire)).toBe(false)
+
+    expect(expire).not.toBeCalled()
+})
+
+it('return true for objects if no expire is undefined', () => {
+    expect(verifyEntry({obj: {data: undefined, meta: {}}}, undefined)).toBe(true)
+})
+
+it('verify object per expire callback', () => {
+    const entry = {obj: {data: undefined, meta: {}}}
+    const expire = jest.fn()
+
+    expire.mockReturnValueOnce(true)
+    expect(verifyEntry(entry, expire)).toBe(false)
+    expect(expire).toBeCalledTimes(1)
+    expect(expire).toBeCalledWith(entry.obj)
+
+    expire.mockReset()
+
+    expire.mockReturnValueOnce(false)
+    expect(verifyEntry(entry, expire)).toBe(true)
+    expect(expire).toBeCalledTimes(1)
+    expect(expire).toBeCalledWith(entry.obj)
+})
+
+it('verify object per expire timeout', () => {
+
+    expect(verifyEntry({ obj: { data: undefined, meta: {} } }, 5000)).toBe(true)
+    expect(verifyEntry({ obj: { data: undefined, meta: { date: new Date() } } }, 5000)).toBe(true)
+    expect(verifyEntry({ obj: { data: undefined, meta: { date: String(new Date()) } } }, 5000)).toBe(true)
+
+    const oldDate = new Date()
+    oldDate.setTime(oldDate.getTime() - 10000)
+
+    expect(verifyEntry({ obj: { data: undefined, meta: { date: oldDate } } }, 5000)).toBe(false)
+    expect(verifyEntry({ obj: { data: undefined, meta: { date: String(oldDate) } } }, 5000)).toBe(false)
+})


### PR DESCRIPTION
Components using the `useCached` hook now listen on further changes to the cache and rerender - no matter which component caused the change.

**Check**
- [x] This does not introduce breaking changes
- [x] This contains tests for the newly introduced behavior
- [x] This contains documentation of the newly introduced behavior

**How**
When using the `useCached().get` method the component subscribes to the `keys`.
When the loader or another component uses `useCached().set` or other writing methods on at least one of the `keys` the component will rerender.

**Additional information**
<!-- Add screenshots, code examples and the like if that helps explaining the change. -->
